### PR TITLE
Prepare the 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Releases before 0.7.0 predate this file; see the
 
 ## [Unreleased]
 
-### Added — a data pipeline users can run
+## [0.8.0] - 2026-08-20
+
+### Added
 
 - **`lost_years update [--source hld|ssa|who|all]`.** Downloads to a scratch
   directory, builds a typed Parquet table with an explicit Arrow schema,
@@ -37,7 +39,22 @@ Releases before 0.7.0 predate this file; see the
   clients (ssa.gov answers many of them with HTTP 403) and for rebuilding from
   an archived copy. It is also how the test suite stays offline.
 
-### Changed — what ships
+
+- `lost_years_hld(subpopulations=True)` returns one resolved row per
+  sub-population — region, urban/rural, ethnicity, socio-demographic group —
+  instead of the single national total, with the same options on the CLI
+  (`--subpopulations`, `--year-tolerance`, `--no-quarantine`).
+- HLD output exposes the matched period (`hld_year1`, `hld_year2`), the age
+  interval (`hld_age_interval`, `99` for the open top interval), the source
+  table (`hld_ref_id`, `hld_version`, `hld_type_lt`), its internal discrepancy
+  (`hld_ex_discrepancy`) and the candidate count (`hld_n_candidates`).
+- A data dictionary documenting the packaged tables, their known defects and
+  the HLD selection rule.
+- Regression tests that assert real life-expectancy values, using the
+  NCHS-published US tables as an oracle. The suite previously asserted no
+  life-expectancy value at all.
+
+### Changed
 
 - **Only the SSA table ships in the wheel**, as Parquet: 10 KB against the
   previous 52 MB of gzipped CSV and a 54 MB ZIP. HLD is not shipped because
@@ -53,6 +70,21 @@ Releases before 0.7.0 predate this file; see the
 - New dependencies `pyarrow` and `platformdirs`; **`selenium` is no longer a
   runtime dependency** — a browser automation stack was being installed for a
   scraper that ran by hand, if ever.
+
+
+- The usage example notebook is rewritten and re-executed against the new
+  contract. The three COVID-19 notebooks are **not**: their `lost_years_who`
+  cells passed an age mapping that now raises, and their HLD cells relied on
+  the old silent snap to the nearest `Year1`. Re-running those analyses means
+  redoing them rather than re-executing them, so they carry a warning in the
+  docs instead.
+- Adopted the shared `py-canon` project standard: CI, docs, release and
+  Dependabot workflows now call `gojiplus/py-canon` reusable workflows.
+- Documentation builds with `myst-nb` instead of `nbsphinx`, so example
+  notebooks render from their committed outputs and no longer need pandoc or a
+  live kernel.
+- Log messages use deferred `%`-style formatting rather than f-strings.
+- Timestamps in the data-maintenance scripts are timezone-aware (UTC).
 
 ### Fixed
 
@@ -73,24 +105,6 @@ Releases before 0.7.0 predate this file; see the
   income groups and a global total, 726 rows — with nothing to tell them apart.
   A `spatial_type` column now says which is which.
 
-### Removed
-
-- `lost_years.types` and its four exports (`LifeExpectancyResult`,
-  `DataSourceConfig`, `ColumnConfig`, `ColumnMapping`): nothing used them.
-- `lost_years/data/consolidate_data.py`, whose `consolidate_hmd_data()` wrote a
-  hardcoded fake life table into the package tree. HMD is credential-gated with
-  no unattended path, so this is deleted rather than repaired.
-- `lost_years/data_sources.json`, which claimed SSA 2024 while shipping 2022 and
-  did not mention HLD at all. `lost_years sources` reads the live registry.
-- The per-source `update_*.py` maintenance scripts, `schemas.py`,
-  `update_all_data.py` and the WHO scraping notebook, superseded by
-  `lost_years update`.
-- Dead `WHO_COLS`, `LostYearsWHOData.convert_agegroup` and its unused
-  translation cache — leftovers from the age-band indicator the package does
-  not use — and `hld.normalise_code`, which moved to `lost_years.sources.hld`
-  where the repair now happens.
-
-### Fixed — wrong answers
 
 - **HLD returned an arbitrary life table.** The loader read 5 of the file's 21
   columns, dropping every column that identifies *which* published table a row
@@ -106,7 +120,7 @@ Releases before 0.7.0 predate this file; see the
 - **A packaging bug hid two thirds of the national life tables.** The update
   script read the pooled file without `dtype=`, so sub-population codes went
   through float and came back as `'0.0'`; a `== '0'` test kept 550,429 rows
-  where 717,457 qualify. Codes are now normalised on read, and the update
+  where 717,457 qualify. Codes are now normalized on read, and the update
   script preserves them.
 - **`US` returned Australia.** Country input was passed to `str.contains()` as
   an unanchored regular expression. Country codes are now matched exactly and
@@ -125,47 +139,32 @@ Releases before 0.7.0 predate this file; see the
   `who_life_expectancy_at_birth`, and raises `ValueError` if an `age` mapping
   is passed.
 
-### Added
-
-- `lost_years_hld(subpopulations=True)` returns one resolved row per
-  sub-population — region, urban/rural, ethnicity, socio-demographic group —
-  instead of the single national total, with the same options on the CLI
-  (`--subpopulations`, `--year-tolerance`, `--no-quarantine`).
-- HLD output exposes the matched period (`hld_year1`, `hld_year2`), the age
-  interval (`hld_age_interval`, `99` for the open top interval), the source
-  table (`hld_ref_id`, `hld_version`, `hld_type_lt`), its internal discrepancy
-  (`hld_ex_discrepancy`) and the candidate count (`hld_n_candidates`).
-- A data dictionary documenting the packaged tables, their known defects and
-  the HLD selection rule.
-- Regression tests that assert real life-expectancy values, using the
-  NCHS-published US tables as an oracle. The suite previously asserted no
-  life-expectancy value at all.
-
-### Changed
-
-- The usage example notebook is rewritten and re-executed against the new
-  contract. The three COVID-19 notebooks are **not**: their `lost_years_who`
-  cells passed an age mapping that now raises, and their HLD cells relied on
-  the old silent snap to the nearest `Year1`. Re-running those analyses means
-  redoing them rather than re-executing them, so they carry a warning in the
-  docs instead.
-- Adopted the shared `py-canon` project standard: CI, docs, release and
-  Dependabot workflows now call `gojiplus/py-canon` reusable workflows.
-- Documentation builds with `myst-nb` instead of `nbsphinx`, so example
-  notebooks render from their committed outputs and no longer need pandoc or a
-  live kernel.
-- Log messages use deferred `%`-style formatting rather than f-strings.
-- Timestamps in the data-maintenance scripts are timezone-aware (UTC).
-
-### Fixed
 
 - `download_file` sets a request timeout instead of blocking indefinitely.
 - Local (macOS) builds no longer ship `.DS_Store` files inside the wheel.
 - README documentation badge and link point at the real docs URL.
+
+### Removed
+
+- `lost_years.types` and its four exports (`LifeExpectancyResult`,
+  `DataSourceConfig`, `ColumnConfig`, `ColumnMapping`): nothing used them.
+- `lost_years/data/consolidate_data.py`, whose `consolidate_hmd_data()` wrote a
+  hardcoded fake life table into the package tree. HMD is credential-gated with
+  no unattended path, so this is deleted rather than repaired.
+- `lost_years/data_sources.json`, which claimed SSA 2024 while shipping 2022 and
+  did not mention HLD at all. `lost_years sources` reads the live registry.
+- The per-source `update_*.py` maintenance scripts, `schemas.py`,
+  `update_all_data.py` and the WHO scraping notebook, superseded by
+  `lost_years update`.
+- Dead `WHO_COLS`, `LostYearsWHOData.convert_agegroup` and its unused
+  translation cache — leftovers from the age-band indicator the package does
+  not use — and `hld.normalise_code`, which moved to `lost_years.sources.hld`
+  where the repair now happens.
 
 ## [0.7.0]
 
 - Packaged data refresh and Python 3.12+ support.
 
 [Unreleased]: https://github.com/gojiplus/lost-years/commits/master
+[0.8.0]: https://pypi.org/project/lost-years/0.8.0/
 [0.7.0]: https://pypi.org/project/lost-years/0.7.0/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,10 +4,10 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: lost_years
-version: 0.7.0
-date-released: 2025-12-27
-url: https://github.com/gojiplus/lost_years
-repository-code: https://github.com/gojiplus/lost_years
+version: 0.8.0
+date-released: 2026-08-20
+url: https://github.com/gojiplus/lost-years
+repository-code: https://github.com/gojiplus/lost-years
 license: MIT
 authors:
   - family-names: Laohaprapanon

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ lost_years status                # what is installed, and has upstream moved?
 
 An update downloads to a scratch directory, builds a typed Parquet table, checks it against the declared schema, a row-count contract and the published life-expectancy figures, and **only then** swaps it into place. A truncated or corrupt download never replaces a working table. Each installed table carries a manifest recording its source URL, upstream release, fetch time, row count and SHA-256. See the [data dictionary](https://gojiplus.github.io/lost-years/data-dictionary.html) for the columns, the checks and the known upstream defects.
 
-**Every lookup either answers the question asked or says it cannot.** Each function returns a `*_match_status` column, and a row that could not be matched carries a missing life expectancy rather than the nearest number that happened to be in the table. The matching rules for each source are summarised below.
+**Every lookup either answers the question asked or says it cannot.** Each function returns a `*_match_status` column, and a row that could not be matched carries a missing life expectancy rather than the nearest number that happened to be in the table. The matching rules for each source are summarized below.
 
 The package exposes three functions: `lost_years_ssa`, `lost_years_hld`, and `lost_years_who`:
 
@@ -53,19 +53,19 @@ The package exposes three functions: `lost_years_ssa`, `lost_years_hld`, and `lo
 
 ## Application
 
-The figures below were recomputed in August 2026 against the corrected lookups. Each is reproducible from its linked notebook.
+The figures below were recomputed in August 2026 against the corrected lookups. The linked notebooks show the original analyses and are not re-executed against this release: the China notebook needs the `year_tolerance=50` described below before `lost_years_hld` returns anything, and the French daily series cannot be reproduced at all. Each figure and the condition it depends on are stated here.
 
 We illustrate the use of the package by estimating the average number of years by which people's lives are shortened due to coronavirus.
 
-**China:** Using data from [Table 1 of the paper](http://weekly.chinacdc.cn/en/article/id/e53946e2-c6c4-41e9-9a9b-fea8db1a8f51) that gives us the distribution of ages of people who died from COVID-19 in China, with conservative assumptions (assuming the gender of the dead person to be male, taking the middle of age ranges) [we find](https://github.com/gojiplus/lost_years/blob/master/docs/source/examples/corona_virus.ipynb) that people's lives are shortened by **11.5 years** on average. Reproducing this takes an explicit choice: HLD's most recent Chinese life table is from **1981**, so `lost_years_hld` returns no match for a 2020 query unless you pass `year_tolerance=50`, and `hld_year1` then reports 1981. Earlier versions reached back those 39 years silently. These estimates are conservative for one additional reason: there is likely an inverse correlation between people who die and their expected longevity. And note that given a bulk of the deaths are among older people, when people are more infirm, the quality-adjusted years lost is likely yet more modest. Given that the last life tables from China are from 1981 and given life expectancy in China has risen substantially since then (though most gains come from reductions in childhood mortality, etc.), we exploit the recent data from the US, simulating what the losses would be if people had the same aggregate life tables as Americans. Using the most recent SSA data, we find that the number to be **15.5**. Compare this to deaths from road accidents, the modal reason for death among 5-24, and 25-44 ages in the US. Assuming everyone who dies from a traffic accident is a man, and assuming the age of death to be 25, we get **51 years**, roughly 3x as large as coronavirus.
+**China:** Using data from [Table 1 of the paper](http://weekly.chinacdc.cn/en/article/id/e53946e2-c6c4-41e9-9a9b-fea8db1a8f51) that gives us the distribution of ages of people who died from COVID-19 in China, with conservative assumptions (assuming the gender of the dead person to be male, taking the middle of age ranges) [we find](https://github.com/gojiplus/lost-years/blob/master/docs/source/examples/corona_virus.ipynb) that people's lives are shortened by **11.5 years** on average. Reproducing this takes an explicit choice: HLD's most recent Chinese life table is from **1981**, so `lost_years_hld` returns no match for a 2020 query unless you pass `year_tolerance=50`, and `hld_year1` then reports 1981. Earlier versions reached back those 39 years silently. These estimates are conservative for one additional reason: there is likely an inverse correlation between people who die and their expected longevity. And note that given a bulk of the deaths are among older people, when people are more infirm, the quality-adjusted years lost is likely yet more modest. Given that the last life tables from China are from 1981 and given life expectancy in China has risen substantially since then (though most gains come from reductions in childhood mortality, etc.), we exploit the recent data from the US, simulating what the losses would be if people had the same aggregate life tables as Americans. Using the most recent SSA data, we find the number to be **15.5**. Compare this to deaths from road accidents, the modal reason for death among 5-24, and 25-44 ages in the US. Assuming everyone who dies from a traffic accident is a man, and assuming the age of death to be 25, we get **51 years**, roughly 3x as large as coronavirus.
 
 
-**France:** Using [COVID-19 Electronic Death Certification Data (CEPIDC)](https://www.data.gouv.fr/fr/datasets/donnees-de-certification-electronique-des-deces-associes-au-covid-19-cepidc/), like above, we estimate the average number of years lost by people dying of coronavirus. With conservative assumptions (assuming gender of the dead person to be male, taking the middle of age ranges) [we find](https://github.com/gojiplus/lost_years/blob/master/docs/source/examples/corona_virus_fr.ipynb) that people's lives are shortened by **8.9 years** on average, matched against France's own 2020 life table. Surprisingly, the average number of years lost of the people dying of coronavirus [remained steady](https://github.com/gojiplus/lost_years/blob/master/docs/source/examples/corona_virus_fr_daily.ipynb) at about 9 years between March and July 2020. **That daily series cannot currently be reproduced.** It used age-specific WHO life tables, and the packaged WHO data has since been replaced with `WHOSIS_000001` — life expectancy at birth, carrying no age dimension. Restoring it means repointing the WHO loader at GHO indicator `LIFE_0000000035` (`ex` by age); until then `lost_years_who` answers only the at-birth question, and rejects an age column rather than ignoring one.
+**France:** Using [COVID-19 Electronic Death Certification Data (CEPIDC)](https://www.data.gouv.fr/fr/datasets/donnees-de-certification-electronique-des-deces-associes-au-covid-19-cepidc/), like above, we estimate the average number of years lost by people dying of coronavirus. With conservative assumptions (assuming gender of the dead person to be male, taking the middle of age ranges) [we find](https://github.com/gojiplus/lost-years/blob/master/docs/source/examples/corona_virus_fr.ipynb) that people's lives are shortened by **8.9 years** on average, matched against France's own 2020 life table. Surprisingly, the average number of years lost of the people dying of coronavirus [remained steady](https://github.com/gojiplus/lost-years/blob/master/docs/source/examples/corona_virus_fr_daily.ipynb) at about 9 years between March and July 2020. **That daily series cannot currently be reproduced.** It used age-specific WHO life tables, and the packaged WHO data has since been replaced with `WHOSIS_000001` — life expectancy at birth, carrying no age dimension. Restoring it means repointing the WHO loader at GHO indicator `LIFE_0000000035` (`ex` by age); until then `lost_years_who` answers only the at-birth question, and rejects an age column rather than ignoring one.
 
 
 ## Installation
 
-We strongly recommend installing `lost_years` inside a Python virtual environment (see [venv documentation](https://docs.python.org/3/library/venv.html#creating-virtual-environments))
+We strongly recommend installing `lost_years` inside a Python virtual environment (see [venv documentation](https://docs.python.org/3/library/venv.html#creating-virtual-environments)).
 
 ```bash
 pip install lost-years
@@ -75,7 +75,7 @@ pip install lost-years
 
 ### Command Line Interface
 
-The package provides three command-line tools:
+The package provides four command-line tools:
 
 ```bash
 # Install the tables that are not shipped (HLD, WHO)
@@ -95,7 +95,7 @@ All commands expect a CSV file with columns for age, sex and year (and country f
 
 ### As an External Library
 
-Please also look at the Jupyter notebook [example.ipynb](https://github.com/gojiplus/lost_years/blob/master/docs/source/examples/example.ipynb).
+Please also look at the Jupyter notebook [example.ipynb](https://github.com/gojiplus/lost-years/blob/master/docs/source/examples/example.ipynb).
 
 ### As an External Library with Pandas DataFrame
 
@@ -103,7 +103,12 @@ Please also look at the Jupyter notebook [example.ipynb](https://github.com/goji
 >>> import pandas as pd
 >>> from lost_years import lost_years_ssa, lost_years_hld, lost_years_who
 >>>
->>> df = pd.read_csv('lost_years/tests/input.csv')
+>>> df = pd.DataFrame({
+...     'year':    [2003, 2019, 1999, 2001, 2006, 2014, 2004, 2003, 2014, 1997],
+...     'country': ['BRA', 'BLZ', 'PHL', 'THA', 'CHE', 'MNE', 'SLV', 'MKD', 'MKD', 'LBN'],
+...     'age':     [80, 5, 62, 7, 57, 44, 34, 46, 6, 49],
+...     'sex':     ['M', 'M', 'F', 'F', 'F', 'M', 'F', 'M', 'F', 'F'],
+... })
 >>> df
    year country  age sex
 0  2003     BRA   80   M

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -56,7 +56,7 @@ whose SHA-256 no longer matches its manifest is reported as `damaged`.
 
 ### lost_years sources
 
-Prints the registry: home page, download URL, licence and filename for each
+Prints the registry: home page, download URL, license and filename for each
 source. Read it before redistributing anything derived from these tables --
 HLD in particular carries no redistribution grant.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ language = "en"
 html_theme = "furo"
 
 html_theme_options = {
-    "source_repository": "https://github.com/gojiplus/lost_years/",
+    "source_repository": "https://github.com/gojiplus/lost-years/",
     "source_branch": "master",
     "source_directory": "docs/source/",
     "navigation_with_keys": True,

--- a/docs/source/data-dictionary.md
+++ b/docs/source/data-dictionary.md
@@ -56,7 +56,7 @@ Every derived table has a `<name>.parquet.manifest.json` beside it:
 |---|---|
 | `source`, `title`, `home_url` | which database, and where to read its terms |
 | `source_url` | the URL the release is published at |
-| `licence` | redistribution terms |
+| `license` | redistribution terms |
 | `upstream_release` | upstream's own identifier — HLD's release date, SSA's and WHO's table year |
 | `built_from` | `download`, or the local path when `--from-file` was used |
 | `fetched_at` | UTC timestamp of the build |
@@ -296,7 +296,7 @@ aggregates, and `spatial_type` says which is which. Filter on
 | `high_ci` | `float64` | upper bound | | 20 rows |
 
 `ParentLocation` is deliberately **not** carried: GHO puts the WHO *region*
-there, not a country name, which is how Somalia once came to be labelled
+there, not a country name, which is how Somalia once came to be labeled
 "Eastern Mediterranean".
 
 Year is matched to the closest table year with no default limit, and the

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,6 +12,6 @@ Examples <examples>
 Data Dictionary <data-dictionary>
 API Reference <api>
 CLI Reference <cli>
-GitHub <https://github.com/gojiplus/lost_years>
+GitHub <https://github.com/gojiplus/lost-years>
 PyPI <https://pypi.org/project/lost-years/>
 ```

--- a/lost_years/cli.py
+++ b/lost_years/cli.py
@@ -41,7 +41,7 @@ def _describe(source: str) -> str:
         f"{entry.name}: {entry.title}\n"
         f"  home     {entry.home_url}\n"
         f"  download {entry.download_url}\n"
-        f"  licence  {entry.licence}\n"
+        f"  license  {entry.license}\n"
         f"  table    {entry.filename} ({ships})"
     )
 

--- a/lost_years/data/ssa/ssa.parquet.manifest.json
+++ b/lost_years/data/ssa/ssa.parquet.manifest.json
@@ -4,10 +4,10 @@
     "table_year": 2022
   },
   "built_from": "data/ssa/source/ssa-2022.csv",
-  "fetched_at": "2026-08-19T22:56:00+00:00",
+  "fetched_at": "2026-08-20T19:19:19+00:00",
   "filename": "ssa.parquet",
-  "home_url": "https://www.ssa.gov/oact/HistEst/PerLifeTables/",
-  "licence": "Public domain (work of the US federal government)",
+  "home_url": "https://www.ssa.gov/oact/STATS/table4c6.html",
+  "license": "Public domain (work of the US federal government)",
   "raw_sha256": "820f86781a0f7c72c0af845f3daab2d71d1e83fb0127ca0b15287d2a772b5fa9",
   "rows": 120,
   "schema": [
@@ -54,7 +54,7 @@
   ],
   "sha256": "58af52ae294df27096571b51b911bef6fa198b473fc652dd45533c6cc7d994ff",
   "source": "ssa",
-  "source_url": "https://www.ssa.gov/oact/HistEst/PerLifeTables/2022/PerLifeTables2022.html",
+  "source_url": "https://www.ssa.gov/oact/STATS/table4c6.html",
   "title": "SSA period life table",
   "upstream_release": "2022"
 }

--- a/lost_years/datasets.py
+++ b/lost_years/datasets.py
@@ -142,7 +142,7 @@ def build_manifest(
     title: str,
     home_url: str,
     source_url: str,
-    licence: str,
+    license_terms: str,
     upstream_release: str,
     built_from: str,
     table: Path,
@@ -156,7 +156,7 @@ def build_manifest(
         title: Human-readable name of the upstream database.
         home_url: Landing page a user should cite and read the terms on.
         source_url: URL the raw artifact was downloaded from.
-        licence: Redistribution terms of the upstream data.
+        license_terms: Redistribution terms of the upstream data.
         upstream_release: Upstream's own identifier for this release.
         built_from: ``"download"``, or the local path the table was built from
             when the download was bypassed.
@@ -175,7 +175,7 @@ def build_manifest(
         "title": title,
         "home_url": home_url,
         "source_url": source_url,
-        "licence": licence,
+        "license": license_terms,
         "upstream_release": upstream_release,
         "built_from": built_from,
         "fetched_at": datetime.now(tz=UTC).isoformat(timespec="seconds"),

--- a/lost_years/sources/base.py
+++ b/lost_years/sources/base.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # Public hosts serving multi-megabyte files; the timeout is per-read, not for
 # the whole transfer.
 READ_TIMEOUT = 120
-USER_AGENT = "lost-years (https://github.com/gojiplus/lost_years)"
+USER_AGENT = "lost-years (https://github.com/gojiplus/lost-years)"
 
 
 class SourceUnavailableError(RuntimeError):
@@ -37,7 +37,7 @@ class Source(ABC):
     title: str
     home_url: str
     download_url: str
-    licence: str
+    license: str
     filename: str
     # A release never has fewer rows than the one the package was tested
     # against, so a short table means a truncated or partial download.

--- a/lost_years/sources/hld.py
+++ b/lost_years/sources/hld.py
@@ -181,7 +181,7 @@ class HLD(Source):
     title = "Human Life-Table Database"
     home_url = "https://www.lifetable.de/"
     download_url = "https://www.lifetable.de/File/GetDocument/data/hld.zip"
-    licence = (
+    license = (
         "No affirmative redistribution grant. lifetable.de asks that users "
         "download their own copy; see https://www.lifetable.de/ for the user "
         "agreement."

--- a/lost_years/sources/ssa.py
+++ b/lost_years/sources/ssa.py
@@ -64,7 +64,7 @@ class SSA(Source):
     title = "SSA period life table"
     home_url = HOME_URL
     download_url = TABLE_URL
-    licence = "Public domain (work of the US federal government)"
+    license = "Public domain (work of the US federal government)"
     filename = "ssa.parquet"
     min_rows = EXPECTED_AGES
     ships_in_wheel = True

--- a/lost_years/sources/who.py
+++ b/lost_years/sources/who.py
@@ -34,7 +34,7 @@ HOME_URL = "https://www.who.int/data/gho"
 
 # ISO-3166 alpha-3 to country name, built from the REST Countries API. GHO
 # returns only the code, and its `ParentLocation` is the WHO *region*, which is
-# how Somalia came to be labelled "Eastern Mediterranean" in an earlier release.
+# how Somalia came to be labeled "Eastern Mediterranean" in an earlier release.
 COUNTRY_NAMES = files("lost_years") / "data" / "who" / "iso_country_mapping.json"
 
 COLUMNS = [
@@ -103,7 +103,7 @@ class WHO(Source):
     title = "WHO Global Health Observatory, life expectancy at birth"
     home_url = HOME_URL
     download_url = API_URL
-    licence = "CC BY 4.0"
+    license = "CC BY 4.0"
     filename = "who.parquet"
     min_rows = 12_936
 

--- a/lost_years/update.py
+++ b/lost_years/update.py
@@ -102,7 +102,7 @@ def update(
             title=source.title,
             home_url=source.home_url,
             source_url=source.url_for(release),
-            licence=source.licence,
+            license_terms=source.license,
             upstream_release=release,
             built_from=str(from_file) if from_file else "download",
             table=candidate,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/gojiplus/lost_years"
+Homepage = "https://github.com/gojiplus/lost-years"
 Documentation = "https://gojiplus.github.io/lost-years/"
-Repository = "https://github.com/gojiplus/lost_years.git"
-Issues = "https://github.com/gojiplus/lost_years/issues"
+Repository = "https://github.com/gojiplus/lost-years.git"
+Issues = "https://github.com/gojiplus/lost-years/issues"
 
 [project.scripts]
 lost_years = "lost_years.cli:main"

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -104,7 +104,7 @@ class TestManifest:
         assert manifest is not None
         assert manifest["source_url"] == source.download_url
         assert manifest["home_url"] == source.home_url
-        assert manifest["licence"] == source.licence
+        assert manifest["license"] == source.license
         assert manifest["upstream_release"]
         assert manifest["fetched_at"].endswith("+00:00")
         assert manifest["rows"] == pq.read_metadata(table).num_rows


### PR DESCRIPTION
Closes out the changelog for 0.8.0 and fixes what a release audit turned up. No functional change to the lookups.

**Changelog.** The 0.8.0 entry had accumulated as three PRs' fragments under one `Unreleased` heading, leaving three `### Fixed` sections and two each of `Added` and `Changed`. Merged into one section per type; all 37 bullets preserved verbatim.

**`licence` → `license`.** The British spelling had hardened into the API: a `Source.licence` attribute, a `"licence"` key in every provenance manifest, and a documented data-dictionary column. 0.8.0 is the first release that writes those manifests, so this is the last moment to rename it without breaking anyone. `build_manifest`'s parameter is `license_terms` (plain `license` shadows a builtin, ruff A002); the key it writes is `"license"`.

**Shipped SSA manifest.** It recorded `home_url` and `source_url` as the `HistEst/PerLifeTables` pages, which hold no table — provenance written before those URLs were corrected in the source class. Rebuilt from the archived CSV; the Parquet comes out byte-identical (`58af52ae…`), so only those two fields and the timestamp change.

**README.** "Each is reproducible from its linked notebook" was false for two of the three COVID notebooks — the China one returns no matches without the `year_tolerance=50` the README itself describes, and the daily French series cannot be reproduced at all. The figures themselves hold; recomputed against this release at 11.48, 15.49 and 8.89 (README rounds to 11.5 / 15.5 / 8.9). Separately, the runnable example read `lost_years/tests/input.csv`, a path in neither the repo nor the wheel, so it now builds its frame inline; and "three command-line tools" introduced four.

**URLs.** `github.com/gojiplus/lost_years` 301s to `lost-years`. Normalized across `pyproject.toml`, `CITATION.cff`, README, docs and the User-Agent sent to upstream hosts.

### Verification

| check | result |
|---|---|
| `pytest` | 118 passed, 0 skipped |
| `ruff check` / `format --check` | clean, 36 files formatted |
| `pyright` | 0 errors, 0 warnings |
| `pydoclint` | no violations |
| `twine check` | both artifacts PASSED |
| documented examples | SSA, HLD and WHO blocks reproduce the README output verbatim |
| wheel contents | `ssa.parquet` (9,994 B) + manifest; no `data/`, no `.DS_Store` |
| clean-venv install | `0.8.0`, offline SSA lookup correct, `lost_years status` works |
| links | every URL 200 except ssa.gov (403 to all automated clients, documented) |

Independent review (Codex/Gemini) was waived for this release at the maintainer's instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDg9BEDJgFhsixKFjAquNm