### PR TITLE
Update to the py-canon v1.2.0 template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Managed by copier — records template version for `copier update`. Do not edit.
-_commit: v1.1.1
+_commit: v1.2.0
 _src_path: gh:gojiplus/py-canon
 author_email: suriyant@gmail.com
 author_name: Suriyan Laohaprapanon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
   ci:
     uses: gojiplus/py-canon/.github/workflows/reusable-ci.yml@v1
     with:
-      # requires-python floors at 3.12, so the reusable default of 3.11 cannot resolve.
+      # Pinned rather than inherited: the reusable default tracks the fleet's
+      # floor, and requires-python here is >=3.12.
       python-versions: '["3.12", "3.14"]'
       wheel-import: lost_years
       # Measured 90% on this branch; two points of headroom.


### PR DESCRIPTION
`preen check --strict` was exiting 1 on template drift: `.copier-answers.yml` pinned `v1.1.1` while the fleet had moved to `v1.2.0`.

**The bump is a no-op in substance.** v1.2.0 raises the template's Python floor to `>=3.12` and its ruff target to `py312` ([py-canon#58](https://github.com/gojiplus/py-canon/pull/58)). This repo already sets both, so the only real change is the recorded template version.

**copier reported a `pyproject.toml` conflict; it was spurious.** The "after updating" side was the generic template block, and taking it would have dropped the second author, every dependency, all keywords, and reset `version` to `0.1.0`. Resolved by keeping ours, which already conforms to v1.2.0.

**One comment went stale.** `reusable-ci`'s default `python-versions` is now `["3.12", "3.14"]`, so "the reusable default of 3.11 cannot resolve" is no longer the reason for the override. The override stays — the default tracks the fleet floor, and a matrix that silently stops covering the version `requires-python` promises is worse than an explicit list — but the comment now says that instead.

### Verification

```
preen check --strict   exit 0   (was 1)
pytest                 118 passed, 0 skipped
ruff check / format    clean, 36 files
pyright                0 errors, 0 warnings
pydoclint              no violations
twine check            both artifacts PASSED
```

The one remaining preen issue is the info-level flat-layout note, which never gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDg9BEDJgFhsixKFjAquNm