### PR TITLE
Record the real coverage floor in the copier answers

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -3,7 +3,7 @@ _commit: v1.2.0
 _src_path: gh:gojiplus/py-canon
 author_email: suriyant@gmail.com
 author_name: Suriyan Laohaprapanon
-coverage_floor: 78
+coverage_floor: 88
 default_branch: master
 description: Get Expected Number of Years Lost
 needs_cli: true


### PR DESCRIPTION
`.copier-answers.yml` recorded `coverage_floor: 78` while `ci.yml` has enforced **88** since adoption. The answers file is what copier re-renders from, so a future `copier update` would have offered 78 back — the same class of stale-scaffold-answer problem as [gojiplus/preen#61](https://github.com/gojiplus/preen/pull/61), just quieter, because a coverage floor silently dropping ten points looks like nothing at all in a diff.

Re-answered through copier rather than hand-editing the managed file:

```
copier update -d coverage_floor=88 --defaults --conflict inline --trust .
```

That also produced a one-line conflict in `ci.yml` — the re-render wanted to drop the `# Measured 90% on this branch; two points of headroom.` comment — resolved by keeping ours. `ci.yml` is byte-identical to master; the only change here is the recorded answer.

Verified with `preen` upgraded 0.3.2 → 0.4.1: `preen check --strict` exits 0, one info-level flat-layout note remaining. 118 tests pass.